### PR TITLE
Adding support for URL and password of the SMB Network share

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,10 +83,15 @@ var runCmd = &cobra.Command{
 				return 1
 			}
 
-			sharePWD, err := password.Generate(16, 10, 0, false, false)
-			if err != nil {
-				slog.Error("Failed to generate ephemeral password for the network file share", "error", err.Error())
-				return 1
+			sharePWD := sharePasswordFlag
+
+			if sharePWD == "" {
+				var err error
+				sharePWD, err = password.Generate(16, 10, 0, false, false)
+				if err != nil {
+					slog.Error("Failed to generate ephemeral password for the network file share", "error", err.Error())
+					return 1
+				}
 			}
 
 			lg := slog.With("backend", shareBackendFlag)
@@ -130,6 +135,7 @@ var (
 	luksFlag               bool
 	allowLUKSLowMemoryFlag bool
 	shareListenIPFlag      string
+	sharePasswordFlag      string
 	ftpExtIPFlag           string
 	shareBackendFlag       string
 	smbUseExternAddrFlag   bool
@@ -153,6 +159,7 @@ func init() {
 
 	runCmd.Flags().StringVar(&shareBackendFlag, "share-backend", defaultShareType, `Specifies the file share backend to use. The default value is OS-specific. (available "smb", "afp", "ftp")`)
 	runCmd.Flags().StringVar(&shareListenIPFlag, "share-listen", share.GetDefaultListenIPStr(), "Specifies the IP to bind the network share port to. NOTE: For FTP, changing the bind address is not enough to connect remotely. You should also specify --ftp-extip.")
+	runCmd.Flags().StringVar(&sharePasswordFlag, "share-password", "", "Specifies a fixed password to connect to the share, when applicable.")
 
 	runCmd.Flags().StringVar(&ftpExtIPFlag, "ftp-extip", share.GetDefaultListenIPStr(), "Specifies the external IP the FTP server should advertise.")
 	runCmd.Flags().BoolVar(&smbUseExternAddrFlag, "smb-extern", share.IsSMBExtModeDefault(), "Specifies whether Linsk emulate external networking for the VM's SMB server. This is the default for Windows as there is no way to specify ports in Windows SMB client.")


### PR DESCRIPTION
Attempt at addressing #3 

1. Added support for `--share-password` flag.

    By default, "sharePWD" will be an empty string.
    In that case, it will be overriden with the default random generated password.
    Otherwise, it will use the string specified as `--shared-password`.
    - [x] Implement
    - [x] :hourglass: Test on Windows again

2. :hourglass: [WIP] Adding support for something like `--share-name` to have a fixed SMB Share name on Windows at least.
    - [ ] :hourglass: Implement
    - [ ] :hourglass: Test on Windows again

3. Run tests
```bash
# make lint-deps
# make security-check-deps

make lint
make security-check
```