### PR TITLE
Add support for custom mount options

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -80,13 +80,18 @@ var runCmd = &cobra.Command{
 				fsToLog = fsTypeOverride
 			}
 
-			slog.Info("Mounting the device", "dev", vmMountDevName, "fs", fsToLog, "luks", luksFlag)
+			mountOptionsToLog := "<default>"
+			if mountOptionsFlag != "" {
+				mountOptionsToLog = mountOptionsFlag
+			}
 
-			err := fm.Mount(vmMountDevName, vm.MountOptions{
+			slog.Info("Mounting the device", "dev", vmMountDevName, "fs", fsToLog, "luks", luksFlag, "mountoptions", mountOptionsToLog)
+
+			err := fm.Mount(vmMountDevName, vm.MountConfig{
 				LUKSContainerPreopen: vmRuntimeLUKSContainerDevice,
-
-				FSTypeOverride: fsTypeOverride,
-				LUKS:           luksFlag,
+				FSTypeOverride:       fsTypeOverride,
+				LUKS:                 luksFlag,
+				MountOptions:         mountOptionsFlag,
 			})
 			if err != nil {
 				slog.Error("Failed to mount the disk inside the VM", "error", err.Error())
@@ -143,6 +148,7 @@ var (
 	shareBackendFlag     string
 	smbUseExternAddrFlag bool
 	debugShellFlag       bool
+	mountOptionsFlag     string
 )
 
 func init() {
@@ -164,4 +170,5 @@ func init() {
 
 	runCmd.Flags().StringVar(&ftpExtIPFlag, "ftp-extip", share.GetDefaultListenIPStr(), "Specifies the external IP the FTP server should advertise.")
 	runCmd.Flags().BoolVar(&smbUseExternAddrFlag, "smb-extern", share.IsSMBExtModeDefault(), "Specifies whether Linsk emulate external networking for the VM's SMB server. This is the default for Windows as there is no way to specify ports in Windows SMB client.")
+	runCmd.Flags().StringVar(&mountOptionsFlag, "mount-options", "", "Specifies the mount options to be passed to the -o flag of mount")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -169,6 +169,6 @@ func init() {
 	runCmd.Flags().StringVar(&shareListenIPFlag, "share-listen", share.GetDefaultListenIPStr(), "Specifies the IP to bind the network share port to. NOTE: For FTP, changing the bind address is not enough to connect remotely. You should also specify --ftp-extip.")
 
 	runCmd.Flags().StringVar(&ftpExtIPFlag, "ftp-extip", share.GetDefaultListenIPStr(), "Specifies the external IP the FTP server should advertise.")
-	runCmd.Flags().BoolVar(&smbUseExternAddrFlag, "smb-extern", share.IsSMBExtModeDefault(), "Specifies whether Linsk emulate external networking for the VM's SMB server. This is the default for Windows as there is no way to specify ports in Windows SMB client.")
+	runCmd.Flags().BoolVar(&smbUseExternAddrFlag, "smb-extern", share.IsSMBExtModeDefault(), "Specifies whether Linsk should emulate external networking for the VM's SMB server. This is the default for Windows as there is no way to specify ports in Windows SMB client.")
 	runCmd.Flags().StringVar(&mountOptionsFlag, "mount-options", "", "Specifies the mount options to be passed to the -o flag of the mount.")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -170,5 +170,5 @@ func init() {
 
 	runCmd.Flags().StringVar(&ftpExtIPFlag, "ftp-extip", share.GetDefaultListenIPStr(), "Specifies the external IP the FTP server should advertise.")
 	runCmd.Flags().BoolVar(&smbUseExternAddrFlag, "smb-extern", share.IsSMBExtModeDefault(), "Specifies whether Linsk emulate external networking for the VM's SMB server. This is the default for Windows as there is no way to specify ports in Windows SMB client.")
-	runCmd.Flags().StringVar(&mountOptionsFlag, "mount-options", "", "Specifies the mount options to be passed to the -o flag of mount")
+	runCmd.Flags().StringVar(&mountOptionsFlag, "mount-options", "", "Specifies the mount options to be passed to the -o flag of the mount.")
 }

--- a/utils/validations.go
+++ b/utils/validations.go
@@ -37,10 +37,16 @@ func ClearUnprintableChars(s string, allowNewlines bool) string {
 	}, s)
 }
 
-var fsTypeRegex = regexp.MustCompile(`^[a-z0-9]+$`)
+var fsTypeRegexp = regexp.MustCompile(`^[a-z0-9]+$`)
 
 func ValidateFsType(s string) bool {
-	return fsTypeRegex.MatchString(s)
+	return fsTypeRegexp.MatchString(s)
+}
+
+var mountOptionsRegexp = regexp.MustCompile(`^([a-zA-Z0-9_]+(=[a-zA-Z0-9]+)?)(,[a-zA-Z0-9_]+(=[a-zA-Z0-9]+)?)*$`)
+
+func ValidateMountOptions(s string) bool {
+	return mountOptionsRegexp.MatchString(s)
 }
 
 var devNameRegexp = regexp.MustCompile(`^[0-9A-Za-z_-]+$`)

--- a/vm/filemanager.go
+++ b/vm/filemanager.go
@@ -231,7 +231,7 @@ func (fm *FileManager) Mount(devName string, mc MountConfig) error {
 	var mountOptions string
 	if mc.MountOptions != "" {
 		if !utils.ValidateMountOptions(mc.MountOptions) {
-			return fmt.Errorf("invalid mount options (contain illegal characters)")
+			return fmt.Errorf("invalid mount options (contains illegal characters)")
 		}
 		mountOptions = mc.MountOptions
 	}

--- a/vm/filemanager.go
+++ b/vm/filemanager.go
@@ -82,11 +82,12 @@ func (fm *FileManager) Lsblk() ([]byte, error) {
 	return ret, nil
 }
 
-type MountOptions struct {
+type MountConfig struct {
 	LUKSContainerPreopen string
 
 	FSTypeOverride string
 	LUKS           bool
+	MountOptions   string
 }
 
 func (fm *FileManager) luksOpen(sc *ssh.Client, fullDevPath string, luksDMName string) error {
@@ -202,7 +203,7 @@ func (fm *FileManager) preopenLUKSContainerWithSSH(sc *ssh.Client, containerDevP
 	return nil
 }
 
-func (fm *FileManager) Mount(devName string, mo MountOptions) error {
+func (fm *FileManager) Mount(devName string, mc MountConfig) error {
 	if devName == "" {
 		return fmt.Errorf("device name is empty")
 	}
@@ -220,13 +221,19 @@ func (fm *FileManager) Mount(devName string, mo MountOptions) error {
 	fullDevPath := "/dev/" + devName
 
 	var fsOverride string
-
-	if mo.FSTypeOverride != "" {
-		if !utils.ValidateFsType(mo.FSTypeOverride) {
+	if mc.FSTypeOverride != "" {
+		if !utils.ValidateFsType(mc.FSTypeOverride) {
 			return fmt.Errorf("bad fs type override (contains illegal characters)")
 		}
+		fsOverride = mc.FSTypeOverride
+	}
 
-		fsOverride = mo.FSTypeOverride
+	var mountOptions string
+	if mc.MountOptions != "" {
+		if !utils.ValidateMountOptions(mc.MountOptions) {
+			return fmt.Errorf("invalid mount options (contain illegal characters)")
+		}
+		mountOptions = mc.MountOptions
 	}
 
 	sc, err := fm.vm.DialSSH()
@@ -236,14 +243,14 @@ func (fm *FileManager) Mount(devName string, mo MountOptions) error {
 
 	defer func() { _ = sc.Close() }()
 
-	if mo.LUKSContainerPreopen != "" {
-		err := fm.preopenLUKSContainerWithSSH(sc, mo.LUKSContainerPreopen)
+	if mc.LUKSContainerPreopen != "" {
+		err := fm.preopenLUKSContainerWithSSH(sc, mc.LUKSContainerPreopen)
 		if err != nil {
 			return errors.Wrap(err, "preopen luks container")
 		}
 	}
 
-	if mo.LUKS {
+	if mc.LUKS {
 		luksDMName := "cryptmnt"
 
 		err = fm.luksOpen(sc, fullDevPath, luksDMName)
@@ -257,6 +264,9 @@ func (fm *FileManager) Mount(devName string, mo MountOptions) error {
 	cmd := "mount "
 	if fsOverride != "" {
 		cmd += "-t " + shellescape.Quote(fsOverride) + " "
+	}
+	if mountOptions != "" {
+		cmd += "-o " + shellescape.Quote(mountOptions) + " "
 	}
 	cmd += shellescape.Quote(fullDevPath) + " /mnt"
 


### PR DESCRIPTION
This PR introduces a new feature that allows users to pass custom `mount` options in the `run` command.
This allows for more flexibility in some scenarios, such as mounting read-only or specifying other filesystem-specific options.

The motivation was that I needed to set `noatime` and a custom `fmask`, and had to manually remount the disk with `mount -o remount` in the debug shell. It seems more appropriate to make this configurable, like the already existing filesystem type override.

### Changes
1. Added a new `--mount-options` flag to the `run` command in `cmd/run.go`.
2. Renamed the `MountOptions` struct in `vm/filemanager.go` to `MountConfig` to avoid confusion as I added a new `MountOptions` field to it.
3. Modified the `Mount` function in `vm/filemanager.go` to use the new mount options when building the mount command
4. Implemented a `ValidateMountOptions` function in `utils/validations.go` with a regexp that allows for multiple comma separated options.
5. Minor typo fix in the FS override validation function, for consistency.

### Testing
- Tested with various mount options to ensure they are correctly passed to the mount command.
- Verified that invalid mount options are rejected by the validation function.

Notes :
- With this change, it might make sense to also move the filesystem type override from a positional argument to a flag (e.g., `--fs-type`) for consistency. But I left this alone as it would be a breaking change in the CLI.
- It could be beneficial to validate user-supplied options like this one earlier in the process (before attempting to boot the VM)