### PR TITLE
Include user/password in share URL

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -101,7 +101,7 @@ var runCmd = &cobra.Command{
 
 			lg := slog.With("backend", shareBackendFlag)
 
-			shareURI, err := backend.Apply(sharePWD, &share.VMShareContext{
+			shareURL, fullURL, err := backend.Apply(sharePWD, &share.VMShareContext{
 				Instance:    i,
 				FileManager: fm,
 				NetTapCtx:   tapCtx,
@@ -113,7 +113,19 @@ var runCmd = &cobra.Command{
 
 			lg.Info("Started the network share successfully")
 
-			fmt.Fprintf(os.Stderr, "===========================\n[Network File Share Config]\nThe network file share was started. Please use the credentials below to connect to the file server.\n\nType: "+strings.ToUpper(shareBackendFlag)+"\nURL: %v\nUsername: linsk\nPassword: %v\n===========================\n", shareURI, sharePWD)
+			fmt.Fprintf(os.Stderr, "===========================\n"+
+				"[Network File Share Config]\n"+
+				"The network file share was started. Please use the credentials below to connect to the file server.\n\n"+
+				"Type: %v\n"+
+				"URL: %v\n"+
+				"Username: linsk\n"+
+				"Password: %v\n", strings.ToUpper(shareBackendFlag), shareURL, sharePWD)
+
+			if fullURL != "" {
+				fmt.Fprintf(os.Stderr, "Full URL: %v\n", fullURL)
+			}
+
+			fmt.Fprintf(os.Stderr, "===========================\n")
 
 			ctxWait := true
 

--- a/share/afp.go
+++ b/share/afp.go
@@ -47,11 +47,14 @@ func NewAFPBackend(uc *UserConfiguration) (Backend, *VMShareOptions, error) {
 		}, nil
 }
 
-func (b *AFPBackend) Apply(sharePWD string, vc *VMShareContext) (string, error) {
+func (b *AFPBackend) Apply(sharePWD string, vc *VMShareContext) (string, string, error) {
 	err := vc.FileManager.StartAFP(sharePWD)
 	if err != nil {
-		return "", errors.Wrap(err, "start afp server")
+		return "", "", errors.Wrap(err, "start afp server")
 	}
 
-	return "afp://linsk:" + sharePWD + "@" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(b.sharePort)) + "/linsk", nil
+	shareURL := "afp://" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(b.sharePort)) + "/linsk"
+	fullURL := "afp://linsk:" + sharePWD + "@" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(b.sharePort)) + "/linsk"
+
+	return shareURL, fullURL, nil
 }

--- a/share/afp.go
+++ b/share/afp.go
@@ -53,5 +53,5 @@ func (b *AFPBackend) Apply(sharePWD string, vc *VMShareContext) (string, error) 
 		return "", errors.Wrap(err, "start afp server")
 	}
 
-	return "afp://" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(b.sharePort)) + "/linsk", nil
+	return "afp://linsk:" + sharePWD + "@" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(b.sharePort)) + "/linsk", nil
 }

--- a/share/backend.go
+++ b/share/backend.go
@@ -19,7 +19,7 @@ package share
 type NewBackendFunc func(uc *UserConfiguration) (Backend, *VMShareOptions, error)
 
 type Backend interface {
-	Apply(sharePWD string, vc *VMShareContext) (string, error)
+	Apply(sharePWD string, vc *VMShareContext) (shareURL string, fullURL string, err error)
 }
 
 var backends = map[string]NewBackendFunc{

--- a/share/ftp.go
+++ b/share/ftp.go
@@ -73,5 +73,5 @@ func (b *FTPBackend) Apply(sharePWD string, vc *VMShareContext) (string, error) 
 		return "", errors.Wrap(err, "start ftp server")
 	}
 
-	return "ftp://" + b.extIP.String() + ":" + fmt.Sprint(b.sharePort), nil
+	return "ftp://linsk:" + sharePWD + "@" + b.extIP.String() + ":" + fmt.Sprint(b.sharePort), nil
 }

--- a/share/ftp.go
+++ b/share/ftp.go
@@ -63,15 +63,18 @@ func NewFTPBackend(uc *UserConfiguration) (Backend, *VMShareOptions, error) {
 		}, nil
 }
 
-func (b *FTPBackend) Apply(sharePWD string, vc *VMShareContext) (string, error) {
+func (b *FTPBackend) Apply(sharePWD string, vc *VMShareContext) (string, string, error) {
 	if vc.NetTapCtx != nil {
-		return "", fmt.Errorf("net taps are unsupported in ftp")
+		return "", "", fmt.Errorf("net taps are unsupported in ftp")
 	}
 
 	err := vc.FileManager.StartFTP(sharePWD, b.sharePort+1, b.passivePortCount, b.extIP)
 	if err != nil {
-		return "", errors.Wrap(err, "start ftp server")
+		return "", "", errors.Wrap(err, "start ftp server")
 	}
 
-	return "ftp://linsk:" + sharePWD + "@" + b.extIP.String() + ":" + fmt.Sprint(b.sharePort), nil
+	shareURL := "ftp://" + net.JoinHostPort(b.extIP.String(), fmt.Sprint(b.sharePort))
+	fullURL := "ftp://linsk:" + sharePWD + "@" + net.JoinHostPort(b.extIP.String(), fmt.Sprint(b.sharePort))
+
+	return shareURL, fullURL, nil
 }

--- a/share/smb.go
+++ b/share/smb.go
@@ -77,12 +77,12 @@ func (b *SMBBackend) Apply(sharePWD string, vc *VMShareContext) (string, error) 
 	var shareURL string
 	switch {
 	case b.sharePort != nil:
-		shareURL = "smb://" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(*b.sharePort)) + "/linsk"
+		shareURL = "smb://linsk:" + sharePWD + "@" + net.JoinHostPort(b.listenIP.String(), fmt.Sprint(*b.sharePort)) + "/linsk"
 	case vc.NetTapCtx != nil:
 		if osspecifics.IsWindows() {
 			shareURL = `\\` + strings.ReplaceAll(vc.NetTapCtx.Net.GuestIP.String(), ":", "-") + ".ipv6-literal.net" + `\linsk`
 		} else {
-			shareURL = "smb://" + net.JoinHostPort(vc.NetTapCtx.Net.GuestIP.String(), fmt.Sprint(smbPort)) + "/linsk"
+			shareURL = "smb://linsk:" + sharePWD + "@" + net.JoinHostPort(vc.NetTapCtx.Net.GuestIP.String(), fmt.Sprint(smbPort)) + "/linsk"
 		}
 	default:
 		return "", fmt.Errorf("no port forwarding and net tap configured")


### PR DESCRIPTION
Small QoL improvement to include the user / password of the share directly in the generated URL (except for SMB on Windows as I'm not sure the syntax is the same)

This allows for Cmd/Ctrl-clicking it from the terminal and be logged in instantly !

At first glance I don't believe there are adverse security consequences to that.

Tested with SMB on macOS only.