### PR TITLE
Updated image.go and efibios.go

### DIFF
--- a/constants/efibios.go
+++ b/constants/efibios.go
@@ -18,13 +18,13 @@ package constants
 
 import "github.com/AlexSSD7/linsk/utils"
 
-const aarch64EFIImageBZ2URL = "https://github.com/qemu/qemu/raw/e3404e01c7f74efdc3440ddfd339d67bf7a8410e/pc-bios/edk2-aarch64-code.fd.bz2"
+const aarch64EFIImageBZ2URL = "https://github.com/qemu/qemu/raw/92ec7805190313c9e628f8fc4eb4f932c15247bd/pc-bios/edk2-aarch64-code.fd.bz2"
 const aarch64EFIImageName = "edk2-aarch64-code.fd"
 
 var aarch64EFIImageHash []byte
 
 func init() {
-	aarch64EFIImageHash = utils.MustDecodeHex("c0c78f7443cce15bcc91a8b6966e759c8c5cf5c80ac0086d5d79b0455fc9ccb5")
+	aarch64EFIImageHash = utils.MustDecodeHex("47765fe344818cbc464b1c14ae658fb4b854f5c2ceffa982411731eb4865594d")
 }
 
 func GetAarch64EFIImageName() string {

--- a/constants/image.go
+++ b/constants/image.go
@@ -22,7 +22,7 @@ import (
 	"github.com/AlexSSD7/linsk/utils"
 )
 
-const baseAlpineVersionMajor = "3.18"
+const baseAlpineVersionMajor = "3.20"
 const baseAlpineVersionMinor = "3"
 const baseAlpineVersionCombined = baseAlpineVersionMajor + "." + baseAlpineVersionMinor
 
@@ -34,10 +34,10 @@ var alpineBaseImageHash []byte
 
 func init() {
 	baseAlpineArch = "x86_64"
-	alpineBaseImageHash = utils.MustDecodeHex("925f6bc1039a0abcd0548d2c3054d54dce31cfa03c7eeba22d10d85dc5817c98")
+	alpineBaseImageHash = utils.MustDecodeHex("81df854fbd7327d293c726b1eeeb82061d3bc8f5a86a6f77eea720f6be372261")
 	if runtime.GOARCH == "arm64" {
 		baseAlpineArch = "aarch64"
-		alpineBaseImageHash = utils.MustDecodeHex("c94593729e4577650d9e73ada28e3cbe56964ab2a27240364f8616e920ed6d4e")
+		alpineBaseImageHash = utils.MustDecodeHex("dbd0c2eaa0bfa39e18d075dae07760a9055ffdee0a338c8a35059413b0f76fec")
 	}
 
 	baseImageURL = "https://dl-cdn.alpinelinux.org/alpine/v" + baseAlpineVersionMajor + "/releases/" + baseAlpineArch + "/alpine-virt-" + baseAlpineVersionCombined + "-" + baseAlpineArch + ".iso"


### PR DESCRIPTION
Updating efibios to latest release from qemu repo at this date.

VM image updated to alpine 3.20, to grab a newer version of qemu (9.0.2 instead of 8.0.5 on alpine v3.18).

This seems to fix the Timeout bug at VM start on Apple Silicon Macs (at least on my M3).